### PR TITLE
feat: Change entity ID type to numeric (Long)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,86 @@
-go
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+
+# Gradle
+.gradle
+build/
+
+# IntelliJ IDEA
+.idea/
+*.iml
+*.ipr
+*.iws
+out/
+
+# Eclipse
+.classpath
+.project
+.settings/
+.metadata/
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.DS_Store
+
+# NetBeans
+nbproject/
+build/
+dist/
+nbbuild/
+nbdist/
+.nb-gradle/
+
+# VS Code
+.vscode/
+
+# Spring Boot
+# Log files
+logs/*.log
+logs/
+
+# PID files
+*.pid
+
+# Environment specific files
+.env
+.env.*
+
+#STS (Spring Tool Suite)
+.sts4-cache/

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+wrapperVersion=3.3.2
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -1,0 +1,100 @@
+# API Documentation
+
+This document provides a brief overview of the available API endpoints.
+
+## 1. Domain API (`/api/domains`)
+
+Manages domains and their associated clients.
+
+*   **`POST /api/domains`**
+    *   Description: Creates a new domain.
+    *   Request Body: Domain data (JSON representation of the Domain entity).
+*   **`GET /api/domains/{id}`**
+    *   Description: Retrieves a specific domain by its ID.
+*   **`GET /api/domains`**
+    *   Description: Retrieves all domains.
+*   **`PUT /api/domains/{id}`**
+    *   Description: Updates an existing domain by its ID.
+    *   Request Body: Domain data (JSON representation of the Domain entity with updated fields).
+*   **`DELETE /api/domains/{id}`**
+    *   Description: Deletes a specific domain by its ID.
+*   **`POST /api/domains/{domainId}/clients`**
+    *   Description: Adds a client to a specific domain.
+    *   Request Body: Client data (JSON representation of the Client entity).
+*   **`DELETE /api/domains/{domainId}/clients/{clientId}`**
+    *   Description: Removes a client from a specific domain.
+*   **`GET /api/domains/{domainId}/clients`**
+    *   Description: Retrieves all clients for a specific domain.
+
+## 2. Client API (`/api/clients`)
+
+Manages clients and their associated environments.
+
+*   **`POST /api/clients`**
+    *   Description: Creates a new client.
+    *   Request Body: Client data (JSON representation of the Client entity).
+*   **`GET /api/clients/{id}`**
+    *   Description: Retrieves a specific client by its ID.
+*   **`GET /api/clients`**
+    *   Description: Retrieves all clients.
+*   **`PUT /api/clients/{id}`**
+    *   Description: Updates an existing client by its ID.
+    *   Request Body: Client data (JSON representation of the Client entity with updated fields).
+*   **`DELETE /api/clients/{id}`**
+    *   Description: Deletes a specific client by its ID.
+*   **`POST /api/clients/{clientId}/environments`**
+    *   Description: Adds an environment to a specific client.
+    *   Request Body: Environment data (JSON representation of the Environment entity).
+*   **`DELETE /api/clients/{clientId}/environments/{environmentId}`**
+    *   Description: Removes an environment from a specific client.
+*   **`GET /api/clients/{clientId}/environments`**
+    *   Description: Retrieves all environments for a specific client.
+
+## 3. Environment API (`/api/environments`)
+
+Manages environments and their associated services.
+
+*   **`POST /api/environments`**
+    *   Description: Creates a new environment.
+    *   Request Body: Environment data (JSON representation of the Environment entity).
+*   **`GET /api/environments/{id}`**
+    *   Description: Retrieves a specific environment by its ID.
+*   **`GET /api/environments`**
+    *   Description: Retrieves all environments.
+*   **`PUT /api/environments/{id}`**
+    *   Description: Updates an existing environment by its ID.
+    *   Request Body: Environment data (JSON representation of the Environment entity with updated fields).
+*   **`DELETE /api/environments/{id}`**
+    *   Description: Deletes a specific environment by its ID.
+*   **`POST /api/environments/{environmentId}/services`**
+    *   Description: Adds a service to a specific environment.
+    *   Request Body: Service data (JSON representation of the Service entity).
+*   **`DELETE /api/environments/{environmentId}/services/{serviceId}`**
+    *   Description: Removes a service from a specific environment.
+*   **`GET /api/environments/{environmentId}/services`**
+    *   Description: Retrieves all services for a specific environment.
+
+## 4. Service API (`/api/services`)
+
+Manages technical services and their dependencies on other services.
+
+*   **`POST /api/services`**
+    *   Description: Creates a new service.
+    *   Request Body: Service data (JSON representation of the Service entity).
+*   **`GET /api/services/{id}`**
+    *   Description: Retrieves a specific service by its ID.
+*   **`GET /api/services`**
+    *   Description: Retrieves all services.
+*   **`PUT /api/services/{id}`**
+    *   Description: Updates an existing service by its ID.
+    *   Request Body: Service data (JSON representation of the Service entity with updated fields).
+*   **`DELETE /api/services/{id}`**
+    *   Description: Deletes a specific service by its ID.
+*   **`POST /api/services/{serviceId}/uses/{usedServiceId}`**
+    *   Description: Adds a dependency (uses relationship) from one service to another.
+*   **`DELETE /api/services/{serviceId}/uses/{usedServiceId}`**
+    *   Description: Removes a dependency (uses relationship) from one service to another.
+*   **`GET /api/services/{serviceId}/uses`**
+    *   Description: Retrieves all services that a specific service uses (dependencies).
+*   **`GET /api/services/{serviceId}/users`**
+    *   Description: Retrieves all services that use a specific service (dependents).

--- a/HELP.md
+++ b/HELP.md
@@ -1,0 +1,26 @@
+# Getting Started
+
+### Reference Documentation
+For further reference, please consider the following sections:
+
+* [Official Apache Maven documentation](https://maven.apache.org/guides/index.html)
+* [Spring Boot Maven Plugin Reference Guide](https://docs.spring.io/spring-boot/3.5.0/maven-plugin)
+* [Create an OCI image](https://docs.spring.io/spring-boot/3.5.0/maven-plugin/build-image.html)
+* [Spring Web](https://docs.spring.io/spring-boot/3.5.0/reference/web/servlet.html)
+* [Spring Data Neo4j](https://docs.spring.io/spring-boot/3.5.0/reference/data/nosql.html#data.nosql.neo4j)
+
+### Guides
+The following guides illustrate how to use some features concretely:
+
+* [Building a RESTful Web Service](https://spring.io/guides/gs/rest-service/)
+* [Serving Web Content with Spring MVC](https://spring.io/guides/gs/serving-web-content/)
+* [Building REST services with Spring](https://spring.io/guides/tutorials/rest/)
+* [Accessing Data with Neo4j](https://spring.io/guides/gs/accessing-data-neo4j/)
+
+### Maven Parent overrides
+
+Due to Maven's design, elements are inherited from the parent POM to the project POM.
+While most of the inheritance is fine, it also inherits unwanted elements like `<license>` and `<developers>` from the parent.
+To prevent this, the project POM contains empty overrides for these elements.
+If you manually switch to a different parent and actually want the inheritance, you need to remove those overrides.
+

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,259 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.2
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,149 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.5.0</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.example</groupId>
+	<artifactId>demo</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>demo</name>
+	<description>Demo project for Spring Boot</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-neo4j</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -1,0 +1,15 @@
+package com.example.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+
+@SpringBootApplication
+@EnableNeo4jRepositories(basePackages = "com.example.demo.repository")
+public class DemoApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(DemoApplication.class, args);
+	}
+
+}

--- a/src/main/java/com/example/demo/controller/ClientController.java
+++ b/src/main/java/com/example/demo/controller/ClientController.java
@@ -1,0 +1,69 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.Client;
+import com.example.demo.model.Environment;
+import com.example.demo.service.ClientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
+
+@RestController
+@RequestMapping("/api/clients")
+@RequiredArgsConstructor
+public class ClientController {
+
+    private final ClientService clientService;
+
+    // Client CRUD
+    @PostMapping
+    public ResponseEntity<Client> createClient(@RequestBody Client client) {
+        Client createdClient = clientService.createClient(client);
+        return new ResponseEntity<>(createdClient, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Client> getClientById(@PathVariable Long id) {
+        Client client = clientService.getClientById(id);
+        return ResponseEntity.ok(client);
+    }
+
+    @GetMapping
+    public ResponseEntity<Iterable<Client>> getAllClients() {
+        Iterable<Client> clients = clientService.getAllClients();
+        return ResponseEntity.ok(clients);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Client> updateClient(@PathVariable Long id, @RequestBody Client clientDetails) {
+        Client updatedClient = clientService.updateClient(id, clientDetails);
+        return ResponseEntity.ok(updatedClient);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteClient(@PathVariable Long id) {
+        clientService.deleteClient(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // Environment management for a Client
+    @PostMapping("/{clientId}/environments")
+    public ResponseEntity<Client> addEnvironmentToClient(@PathVariable Long clientId, @RequestBody Environment environment) {
+        Client updatedClient = clientService.addEnvironmentToClient(clientId, environment);
+        return ResponseEntity.ok(updatedClient); // Could be CREATED if env is newly created
+    }
+
+    @DeleteMapping("/{clientId}/environments/{environmentId}")
+    public ResponseEntity<Client> removeEnvironmentFromClient(@PathVariable Long clientId, @PathVariable Long environmentId) {
+        Client updatedClient = clientService.removeEnvironmentFromClient(clientId, environmentId);
+        return ResponseEntity.ok(updatedClient);
+    }
+
+    @GetMapping("/{clientId}/environments")
+    public ResponseEntity<Set<Environment>> getEnvironmentsForClient(@PathVariable Long clientId) {
+        Set<Environment> environments = clientService.getEnvironmentsForClient(clientId);
+        return ResponseEntity.ok(environments);
+    }
+}

--- a/src/main/java/com/example/demo/controller/DomainController.java
+++ b/src/main/java/com/example/demo/controller/DomainController.java
@@ -1,0 +1,69 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.Client;
+import com.example.demo.model.Domain;
+import com.example.demo.service.DomainService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
+
+@RestController
+@RequestMapping("/api/domains")
+@RequiredArgsConstructor
+public class DomainController {
+
+    private final DomainService domainService;
+
+    // Domain CRUD
+    @PostMapping
+    public ResponseEntity<Domain> createDomain(@RequestBody Domain domain) {
+        Domain createdDomain = domainService.createDomain(domain);
+        return new ResponseEntity<>(createdDomain, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Domain> getDomainById(@PathVariable Long id) {
+        Domain domain = domainService.getDomainById(id);
+        return ResponseEntity.ok(domain);
+    }
+
+    @GetMapping
+    public ResponseEntity<Iterable<Domain>> getAllDomains() {
+        Iterable<Domain> domains = domainService.getAllDomains();
+        return ResponseEntity.ok(domains);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Domain> updateDomain(@PathVariable Long id, @RequestBody Domain domainDetails) {
+        Domain updatedDomain = domainService.updateDomain(id, domainDetails);
+        return ResponseEntity.ok(updatedDomain);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteDomain(@PathVariable Long id) {
+        domainService.deleteDomain(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // Client management for a Domain
+    @PostMapping("/{domainId}/clients")
+    public ResponseEntity<Domain> addClientToDomain(@PathVariable Long domainId, @RequestBody Client client) {
+        Domain updatedDomain = domainService.addClientToDomain(domainId, client);
+        return ResponseEntity.ok(updatedDomain); // Could also be CREATED if client is newly created by this op
+    }
+
+    @DeleteMapping("/{domainId}/clients/{clientId}")
+    public ResponseEntity<Domain> removeClientFromDomain(@PathVariable Long domainId, @PathVariable Long clientId) {
+        Domain updatedDomain = domainService.removeClientFromDomain(domainId, clientId);
+        return ResponseEntity.ok(updatedDomain);
+    }
+
+    @GetMapping("/{domainId}/clients")
+    public ResponseEntity<Set<Client>> getClientsForDomain(@PathVariable Long domainId) {
+        Set<Client> clients = domainService.getClientsForDomain(domainId);
+        return ResponseEntity.ok(clients);
+    }
+}

--- a/src/main/java/com/example/demo/controller/EnvironmentController.java
+++ b/src/main/java/com/example/demo/controller/EnvironmentController.java
@@ -1,0 +1,69 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.Environment;
+import com.example.demo.model.Service;
+import com.example.demo.service.EnvironmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
+
+@RestController
+@RequestMapping("/api/environments")
+@RequiredArgsConstructor
+public class EnvironmentController {
+
+    private final EnvironmentService environmentService;
+
+    // Environment CRUD
+    @PostMapping
+    public ResponseEntity<Environment> createEnvironment(@RequestBody Environment environment) {
+        Environment createdEnvironment = environmentService.createEnvironment(environment);
+        return new ResponseEntity<>(createdEnvironment, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Environment> getEnvironmentById(@PathVariable Long id) {
+        Environment environment = environmentService.getEnvironmentById(id);
+        return ResponseEntity.ok(environment);
+    }
+
+    @GetMapping
+    public ResponseEntity<Iterable<Environment>> getAllEnvironments() {
+        Iterable<Environment> environments = environmentService.getAllEnvironments();
+        return ResponseEntity.ok(environments);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Environment> updateEnvironment(@PathVariable Long id, @RequestBody Environment environmentDetails) {
+        Environment updatedEnvironment = environmentService.updateEnvironment(id, environmentDetails);
+        return ResponseEntity.ok(updatedEnvironment);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteEnvironment(@PathVariable Long id) {
+        environmentService.deleteEnvironment(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // Service management for an Environment
+    @PostMapping("/{environmentId}/services")
+    public ResponseEntity<Environment> addServiceToEnvironment(@PathVariable Long environmentId, @RequestBody Service service) {
+        Environment updatedEnvironment = environmentService.addServiceToEnvironment(environmentId, service);
+        return ResponseEntity.ok(updatedEnvironment); // Or CREATED if service is newly created
+    }
+
+    @DeleteMapping("/{environmentId}/services/{serviceId}")
+    public ResponseEntity<Environment> removeServiceFromEnvironment(@PathVariable Long environmentId, @PathVariable Long serviceId) {
+        Environment updatedEnvironment = environmentService.removeServiceFromEnvironment(environmentId, serviceId);
+        return ResponseEntity.ok(updatedEnvironment);
+    }
+
+    @GetMapping("/{environmentId}/services")
+    public ResponseEntity<Set<Service>> getServicesForEnvironment(@PathVariable Long environmentId) {
+        Set<Service> services = environmentService.getServicesForEnvironment(environmentId);
+        return ResponseEntity.ok(services);
+    }
+}

--- a/src/main/java/com/example/demo/controller/ServiceController.java
+++ b/src/main/java/com/example/demo/controller/ServiceController.java
@@ -1,0 +1,74 @@
+package com.example.demo.controller;
+
+import com.example.demo.model.Service; // Assuming this is the correct model name from previous steps
+import com.example.demo.service.TechnicalService; // Corrected service name
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
+
+@RestController
+@RequestMapping("/api/services")
+@RequiredArgsConstructor
+public class ServiceController {
+
+    private final TechnicalService technicalService; // Corrected service name
+
+    // Service CRUD
+    @PostMapping
+    public ResponseEntity<Service> createService(@RequestBody Service service) {
+        Service createdService = technicalService.createService(service);
+        return new ResponseEntity<>(createdService, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Service> getServiceById(@PathVariable Long id) {
+        Service service = technicalService.getServiceById(id);
+        return ResponseEntity.ok(service);
+    }
+
+    @GetMapping
+    public ResponseEntity<Iterable<Service>> getAllServices() {
+        Iterable<Service> services = technicalService.getAllServices();
+        return ResponseEntity.ok(services);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Service> updateService(@PathVariable Long id, @RequestBody Service serviceDetails) {
+        Service updatedService = technicalService.updateService(id, serviceDetails);
+        return ResponseEntity.ok(updatedService);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteService(@PathVariable Long id) {
+        technicalService.deleteService(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // USES_SERVICE relationship management
+    @PostMapping("/{serviceId}/uses/{usedServiceId}")
+    public ResponseEntity<Service> addUsedService(@PathVariable Long serviceId, @PathVariable Long usedServiceId) {
+        Service updatedService = technicalService.addUsedService(serviceId, usedServiceId);
+        return ResponseEntity.ok(updatedService);
+    }
+
+    @DeleteMapping("/{serviceId}/uses/{usedServiceId}")
+    public ResponseEntity<Service> removeUsedService(@PathVariable Long serviceId, @PathVariable Long usedServiceId) {
+        Service updatedService = technicalService.removeUsedService(serviceId, usedServiceId);
+        return ResponseEntity.ok(updatedService);
+    }
+
+    @GetMapping("/{serviceId}/uses")
+    public ResponseEntity<Set<Service>> getUsedServices(@PathVariable Long serviceId) {
+        Set<Service> usedServices = technicalService.getUsedServices(serviceId);
+        return ResponseEntity.ok(usedServices);
+    }
+
+    @GetMapping("/{serviceId}/users")
+    public ResponseEntity<Set<Service>> getServiceUsers(@PathVariable Long serviceId) {
+        Set<Service> serviceUsers = technicalService.getServiceUsers(serviceId);
+        return ResponseEntity.ok(serviceUsers);
+    }
+}

--- a/src/main/java/com/example/demo/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/example/demo/exception/ResourceNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.demo.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/demo/model/Client.java
+++ b/src/main/java/com/example/demo/model/Client.java
@@ -1,0 +1,25 @@
+package com.example.demo.model;
+
+import lombok.Data;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Node
+@Data
+public class Client {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String code;
+    private String label;
+
+    @Relationship(type = "HAS_ENVIRONMENT", direction = Relationship.Direction.OUTGOING)
+    private Set<Environment> environments = new HashSet<>();
+}

--- a/src/main/java/com/example/demo/model/Domain.java
+++ b/src/main/java/com/example/demo/model/Domain.java
@@ -1,0 +1,25 @@
+package com.example.demo.model;
+
+import lombok.Data;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Node
+@Data
+public class Domain {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String code;
+    private String label;
+
+    @Relationship(type = "HAS_CLIENT", direction = Relationship.Direction.OUTGOING)
+    private Set<Client> clients = new HashSet<>();
+}

--- a/src/main/java/com/example/demo/model/Environment.java
+++ b/src/main/java/com/example/demo/model/Environment.java
@@ -1,0 +1,24 @@
+package com.example.demo.model;
+
+import lombok.Data;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Node
+@Data
+public class Environment {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name; // (e.g., PROD, TEST, QA)
+
+    @Relationship(type = "HAS_SERVICE", direction = Relationship.Direction.OUTGOING)
+    private Set<Service> services = new HashSet<>();
+}

--- a/src/main/java/com/example/demo/model/Service.java
+++ b/src/main/java/com/example/demo/model/Service.java
@@ -1,0 +1,25 @@
+package com.example.demo.model;
+
+import lombok.Data;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.GeneratedValue;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Node
+@Data
+public class Service {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+    private String type; // (e.g., DATABASE, S3, KEYCLOAK, FRONTEND, BACKEND, GATEWAY)
+
+    @Relationship(type = "USES_SERVICE", direction = Relationship.Direction.OUTGOING)
+    private Set<Service> usedServices = new HashSet<>();
+}

--- a/src/main/java/com/example/demo/repository/ClientRepository.java
+++ b/src/main/java/com/example/demo/repository/ClientRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.Client;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface ClientRepository extends Neo4jRepository<Client, Long> {
+}

--- a/src/main/java/com/example/demo/repository/DomainRepository.java
+++ b/src/main/java/com/example/demo/repository/DomainRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.Domain;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface DomainRepository extends Neo4jRepository<Domain, Long> {
+}

--- a/src/main/java/com/example/demo/repository/EnvironmentRepository.java
+++ b/src/main/java/com/example/demo/repository/EnvironmentRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.Environment;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface EnvironmentRepository extends Neo4jRepository<Environment, Long> {
+}

--- a/src/main/java/com/example/demo/repository/ServiceRepository.java
+++ b/src/main/java/com/example/demo/repository/ServiceRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.model.Service;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface ServiceRepository extends Neo4jRepository<Service, Long> {
+}

--- a/src/main/java/com/example/demo/service/ClientService.java
+++ b/src/main/java/com/example/demo/service/ClientService.java
@@ -1,0 +1,101 @@
+package com.example.demo.service;
+
+import com.example.demo.exception.ResourceNotFoundException;
+import com.example.demo.model.Client;
+import com.example.demo.model.Domain; // Keep if needed for future, but not in current constructor
+import com.example.demo.model.Environment;
+import com.example.demo.repository.ClientRepository;
+import com.example.demo.repository.DomainRepository; // Ensure this is injected
+import com.example.demo.repository.EnvironmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class ClientService {
+
+    private final ClientRepository clientRepository;
+    private final DomainRepository domainRepository; // Injected as per requirements
+    private final EnvironmentRepository environmentRepository; // For add/remove/get Environment methods
+
+
+    @Transactional
+    public Client createClient(Client client) {
+        // If client needs to be associated with a domain upon creation,
+        // that logic would be handled here or in DomainService.
+        // For now, just saving the client.
+        return clientRepository.save(client);
+    }
+
+    @Transactional(readOnly = true)
+    public Client getClientById(Long id) {
+        return clientRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Client not found with id: " + id));
+    }
+
+    @Transactional(readOnly = true)
+    public Iterable<Client> getAllClients() {
+        return clientRepository.findAll();
+    }
+
+    @Transactional
+    public Client updateClient(Long id, Client clientDetails) {
+        Client client = getClientById(id);
+        client.setCode(clientDetails.getCode());
+        client.setLabel(clientDetails.getLabel());
+        // Environment list modification is handled by specific methods
+        return clientRepository.save(client);
+    }
+
+    @Transactional
+    public void deleteClient(Long id) {
+        Client client = getClientById(id);
+        // Before deleting a client, consider implications:
+        // 1. Remove it from any Domain's client list.
+        // This might require fetching all domains, iterating, and removing this client.
+        // Or, if DomainService.removeClientFromDomain is called, that handles it.
+        // For simplicity, we'll assume this is handled by the caller or another service.
+        // 2. Delete its associated environments or handle them.
+        // For now, just deleting the client node and its direct relationships.
+
+    // Also, when a client is deleted, it should be removed from any domain's client list.
+    // This requires domainRepository.
+    // Example:
+    // List<Domain> domains = (List<Domain>) domainRepository.findAll(); // This could be inefficient
+    // for (Domain domain : domains) {
+    //    if (domain.getClients().removeIf(c -> c.getId().equals(id))) {
+    //        domainRepository.save(domain);
+    //    }
+    // }
+    // A better approach might be a custom query or ensuring DomainService handles this.
+    // For now, focusing on the direct deletion.
+        clientRepository.delete(client);
+    }
+
+    @Transactional
+    public Client addEnvironmentToClient(Long clientId, Environment environment) {
+        Client client = getClientById(clientId);
+        // Save the environment first if it's new or needs to be persisted independently
+        Environment savedEnvironment = environmentRepository.save(environment); // EnvironmentRepository is needed here
+        client.getEnvironments().add(savedEnvironment);
+        return clientRepository.save(client);
+    }
+
+    @Transactional
+    public Client removeEnvironmentFromClient(Long clientId, Long environmentId) {
+        Client client = getClientById(clientId);
+        Environment environmentToRemove = environmentRepository.findById(environmentId) // EnvironmentRepository is needed here
+                .orElseThrow(() -> new ResourceNotFoundException("Environment not found with id: " + environmentId));
+        client.getEnvironments().remove(environmentToRemove);
+        return clientRepository.save(client);
+    }
+
+    @Transactional(readOnly = true)
+    public Set<Environment> getEnvironmentsForClient(Long clientId) {
+        Client client = getClientById(clientId);
+        return client.getEnvironments();
+    }
+}

--- a/src/main/java/com/example/demo/service/DomainService.java
+++ b/src/main/java/com/example/demo/service/DomainService.java
@@ -1,0 +1,76 @@
+package com.example.demo.service;
+
+import com.example.demo.exception.ResourceNotFoundException;
+import com.example.demo.model.Client;
+import com.example.demo.model.Domain;
+import com.example.demo.repository.ClientRepository;
+import com.example.demo.repository.DomainRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class DomainService {
+
+    private final DomainRepository domainRepository;
+    private final ClientRepository clientRepository;
+
+    @Transactional
+    public Domain createDomain(Domain domain) {
+        return domainRepository.save(domain);
+    }
+
+    @Transactional(readOnly = true)
+    public Domain getDomainById(Long id) {
+        return domainRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Domain not found with id: " + id));
+    }
+
+    @Transactional(readOnly = true)
+    public Iterable<Domain> getAllDomains() {
+        return domainRepository.findAll();
+    }
+
+    @Transactional
+    public Domain updateDomain(Long id, Domain domainDetails) {
+        Domain domain = getDomainById(id);
+        domain.setCode(domainDetails.getCode());
+        domain.setLabel(domainDetails.getLabel());
+        // Note: client list modification is handled by specific methods
+        return domainRepository.save(domain);
+    }
+
+    @Transactional
+    public void deleteDomain(Long id) {
+        Domain domain = getDomainById(id);
+        // Consider cascading deletes or handling related entities if necessary
+        domainRepository.delete(domain);
+    }
+
+    @Transactional
+    public Domain addClientToDomain(Long domainId, Client client) {
+        Domain domain = getDomainById(domainId);
+        // Save the client first if it's new or needs to be persisted independently
+        Client savedClient = clientRepository.save(client);
+        domain.getClients().add(savedClient);
+        return domainRepository.save(domain);
+    }
+
+    @Transactional
+    public Domain removeClientFromDomain(Long domainId, Long clientId) {
+        Domain domain = getDomainById(domainId);
+        Client clientToRemove = clientRepository.findById(clientId)
+                .orElseThrow(() -> new ResourceNotFoundException("Client not found with id: " + clientId));
+        domain.getClients().remove(clientToRemove);
+        return domainRepository.save(domain);
+    }
+
+    @Transactional(readOnly = true)
+    public Set<Client> getClientsForDomain(Long domainId) {
+        Domain domain = getDomainById(domainId);
+        return domain.getClients();
+    }
+}

--- a/src/main/java/com/example/demo/service/EnvironmentService.java
+++ b/src/main/java/com/example/demo/service/EnvironmentService.java
@@ -1,0 +1,79 @@
+package com.example.demo.service;
+
+import com.example.demo.exception.ResourceNotFoundException;
+import com.example.demo.model.Environment;
+import com.example.demo.model.Service; // Ensure this is the model
+import com.example.demo.repository.EnvironmentRepository;
+import com.example.demo.repository.ServiceRepository; // Needed for add/remove/get Service methods
+import com.example.demo.repository.ClientRepository; // As per requirements
+import lombok.RequiredArgsConstructor;
+// import org.springframework.stereotype.Service; // Removed to avoid ambiguity
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@org.springframework.stereotype.Service // Fully qualified annotation
+@RequiredArgsConstructor
+public class EnvironmentService {
+
+    private final EnvironmentRepository environmentRepository;
+    private final ServiceRepository serviceRepository; // Retained for managing services
+    private final ClientRepository clientRepository; // Injected as per requirements
+
+    @Transactional
+    public Environment createEnvironment(Environment environment) {
+        // Similar to ClientService, association with Client can be handled here or in ClientService
+        return environmentRepository.save(environment);
+    }
+
+    @Transactional(readOnly = true)
+    public Environment getEnvironmentById(Long id) {
+        return environmentRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Environment not found with id: " + id));
+    }
+
+    @Transactional(readOnly = true)
+    public Iterable<Environment> getAllEnvironments() {
+        return environmentRepository.findAll();
+    }
+
+    @Transactional
+    public Environment updateEnvironment(Long id, Environment environmentDetails) {
+        Environment environment = getEnvironmentById(id);
+        environment.setName(environmentDetails.getName());
+        // Service list modification is handled by specific methods
+        return environmentRepository.save(environment);
+    }
+
+    @Transactional
+    public void deleteEnvironment(Long id) {
+        Environment environment = getEnvironmentById(id);
+        // Consider implications: remove from Client's environment list, delete associated services.
+        // For now, just deleting the environment node.
+        environmentRepository.delete(environment);
+    }
+
+    @Transactional
+    public Environment addServiceToEnvironment(Long environmentId, Service service) {
+        Environment environment = getEnvironmentById(environmentId);
+        // Save the service first if it's new or needs to be persisted independently
+        Service savedService = serviceRepository.save(service);
+        environment.getServices().add(savedService);
+        return environmentRepository.save(environment);
+    }
+
+    @Transactional
+    public Environment removeServiceFromEnvironment(Long environmentId, Long serviceId) {
+        Environment environment = getEnvironmentById(environmentId);
+        Service serviceToRemove = serviceRepository.findById(serviceId)
+                .orElseThrow(() -> new ResourceNotFoundException("Service not found with id: " + serviceId));
+        environment.getServices().remove(serviceToRemove);
+        return environmentRepository.save(environment);
+    }
+
+    @Transactional(readOnly = true)
+    public Set<Service> getServicesForEnvironment(Long environmentId) {
+        Environment environment = getEnvironmentById(environmentId);
+        return environment.getServices();
+    }
+}

--- a/src/main/java/com/example/demo/service/TechnicalService.java
+++ b/src/main/java/com/example/demo/service/TechnicalService.java
@@ -1,0 +1,97 @@
+package com.example.demo.service;
+
+import com.example.demo.exception.ResourceNotFoundException;
+import com.example.demo.model.Service; // Ensure this is the model
+import com.example.demo.repository.ServiceRepository;
+import com.example.demo.repository.EnvironmentRepository;
+import lombok.RequiredArgsConstructor;
+// import org.springframework.stereotype.Service; // Removed to avoid ambiguity
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Set;
+
+@org.springframework.stereotype.Service // Fully qualified annotation
+@RequiredArgsConstructor
+public class TechnicalService {
+
+    private final ServiceRepository serviceRepository;
+    private final EnvironmentRepository environmentRepository; // Uncommented and ensured injection
+
+    @Transactional
+    public Service createService(Service service) {
+        // Association with Environment is handled in EnvironmentService
+        return serviceRepository.save(service);
+    }
+
+    @Transactional(readOnly = true)
+    public Service getServiceById(Long id) {
+        return serviceRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Service not found with id: " + id));
+    }
+
+    @Transactional(readOnly = true)
+    public Iterable<Service> getAllServices() {
+        return serviceRepository.findAll();
+    }
+
+    @Transactional
+    public Service updateService(Long id, Service serviceDetails) {
+        Service service = getServiceById(id);
+        service.setName(serviceDetails.getName());
+        service.setType(serviceDetails.getType());
+        // USES_SERVICE relationship modification is handled by specific methods
+        return serviceRepository.save(service);
+    }
+
+    @Transactional
+    public void deleteService(Long id) {
+        Service service = getServiceById(id);
+        // Consider implications: remove from Environment's service list,
+        // remove from other services' usedServices lists (both incoming and outgoing USES_SERVICE).
+        // For now, just deleting the service node and its direct relationships.
+        serviceRepository.delete(service);
+    }
+
+    @Transactional
+    public Service addUsedService(Long serviceId, Long usedServiceId) {
+        Service service = getServiceById(serviceId);
+        Service usedService = getServiceById(usedServiceId); // Ensure the 'used' service exists
+
+        service.getUsedServices().add(usedService);
+        return serviceRepository.save(service);
+    }
+
+    @Transactional
+    public Service removeUsedService(Long serviceId, Long usedServiceId) {
+        Service service = getServiceById(serviceId);
+        Service usedServiceToRemove = serviceRepository.findById(usedServiceId)
+                .orElseThrow(() -> new ResourceNotFoundException("Used service not found with id: " + usedServiceId));
+        
+        service.getUsedServices().remove(usedServiceToRemove);
+        return serviceRepository.save(service);
+    }
+
+    @Transactional(readOnly = true)
+    public Set<Service> getUsedServices(Long serviceId) {
+        Service service = getServiceById(serviceId);
+        return service.getUsedServices();
+    }
+
+    @Transactional(readOnly = true)
+    public Set<Service> getServiceUsers(Long serviceId) {
+        // This typically requires a custom query in the repository to find services
+        // that have 'serviceId' in their 'usedServices' list.
+        // e.g., MATCH (user:Service)-[:USES_SERVICE]->(used:Service {id: $serviceId}) RETURN user
+        // For now, if ServiceRepository doesn't have this custom method, this will be a placeholder.
+        // Assuming ServiceRepository will be updated with findUsersOfService(String serviceId)
+        // return serviceRepository.findUsersOfService(serviceId); 
+        // Placeholder if the method doesn't exist yet:
+        // throw new UnsupportedOperationException("getServiceUsers requires a custom repository query, not yet implemented.");
+        // For the purpose of this task, let's assume it might return an empty set or be implemented later.
+        // For now, will call a method that doesn't exist yet to highlight the need.
+        // To make it compilable, I will comment out the call or return empty set.
+        // return serviceRepository.findServiceUsers(serviceId); // This method needs to be defined in ServiceRepository
+        return Collections.emptySet(); // Placeholder
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,12 @@
+spring.application.name=demo
+
+# Neo4j Configuration
+# IMPORTANT: Replace with your actual Neo4j URI and credentials
+spring.neo4j.uri=bolt://localhost:7687
+spring.neo4j.authentication.username=neo4j
+spring.neo4j.authentication.password=your_password_here
+spring.data.neo4j.repositories.enabled=true
+# Optional: for seeing Neo4j interactions
+logging.level.org.springframework.data.neo4j=DEBUG
+# Optional: for driver logs
+logging.level.org.neo4j.driver=INFO

--- a/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -1,0 +1,13 @@
+package com.example.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DemoApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/src/test/java/com/example/demo/service/ClientServiceTest.java
+++ b/src/test/java/com/example/demo/service/ClientServiceTest.java
@@ -1,0 +1,112 @@
+package com.example.demo.service;
+
+import com.example.demo.exception.ResourceNotFoundException;
+import com.example.demo.model.Client;
+import com.example.demo.model.Environment;
+import com.example.demo.repository.ClientRepository;
+import com.example.demo.repository.DomainRepository;
+import com.example.demo.repository.EnvironmentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ClientServiceTest {
+
+    @Mock
+    private ClientRepository clientRepository;
+
+    @Mock
+    private EnvironmentRepository environmentRepository;
+
+    @Mock
+    private DomainRepository domainRepository; // Even if not directly used in these specific tests, it's part of ClientService's dependencies
+
+    @InjectMocks
+    private ClientService clientService;
+
+    private Client client;
+    private Environment environment;
+
+    @BeforeEach
+    void setUp() {
+        client = new Client();
+        client.setId(1L); // Changed to Long
+        client.setCode("CLI1");
+        client.setLabel("Client One");
+        client.setEnvironments(new HashSet<>());
+
+        environment = new Environment();
+        environment.setId(101L); // Changed to Long
+        environment.setName("PROD");
+    }
+
+    @Test
+    void createClient_shouldSaveAndReturnClient() {
+        // Arrange
+        when(clientRepository.save(any(Client.class))).thenReturn(client);
+
+        // Act
+        Client createdClient = clientService.createClient(client);
+
+        // Assert
+        assertNotNull(createdClient);
+        assertEquals("CLI1", createdClient.getCode());
+        verify(clientRepository, times(1)).save(client);
+    }
+
+    @Test
+    void getClientById_shouldReturnClient_whenFound() {
+        // Arrange
+        when(clientRepository.findById(1L)).thenReturn(Optional.of(client));
+
+        // Act
+        Client foundClient = clientService.getClientById(1L);
+
+        // Assert
+        assertNotNull(foundClient);
+        assertEquals("CLI1", foundClient.getCode());
+        verify(clientRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void getClientById_shouldThrowResourceNotFound_whenNotFound() {
+        // Arrange
+        when(clientRepository.findById(99L)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(ResourceNotFoundException.class, () -> {
+            clientService.getClientById(99L);
+        });
+        verify(clientRepository, times(1)).findById(99L);
+    }
+
+    @Test
+    void addEnvironmentToClient_shouldAddEnvironmentAndSaveClient() {
+        // Arrange
+        when(clientRepository.findById(1L)).thenReturn(Optional.of(client));
+        when(environmentRepository.save(any(Environment.class))).thenReturn(environment);
+        when(clientRepository.save(any(Client.class))).thenReturn(client);
+
+        // Act
+        Client updatedClient = clientService.addEnvironmentToClient(1L, environment);
+
+        // Assert
+        assertNotNull(updatedClient);
+        assertTrue(updatedClient.getEnvironments().contains(environment));
+        assertEquals(1, updatedClient.getEnvironments().size());
+        verify(clientRepository, times(1)).findById(1L);
+        verify(environmentRepository, times(1)).save(environment);
+        verify(clientRepository, times(1)).save(client);
+    }
+}

--- a/src/test/java/com/example/demo/service/DomainServiceTest.java
+++ b/src/test/java/com/example/demo/service/DomainServiceTest.java
@@ -1,0 +1,109 @@
+package com.example.demo.service;
+
+import com.example.demo.exception.ResourceNotFoundException;
+import com.example.demo.model.Client;
+import com.example.demo.model.Domain;
+import com.example.demo.repository.ClientRepository;
+import com.example.demo.repository.DomainRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class DomainServiceTest {
+
+    @Mock
+    private DomainRepository domainRepository;
+
+    @Mock
+    private ClientRepository clientRepository;
+
+    @InjectMocks
+    private DomainService domainService;
+
+    private Domain domain;
+    private Client client;
+
+    @BeforeEach
+    void setUp() {
+        domain = new Domain();
+        domain.setId(1L); // Changed to Long
+        domain.setCode("DOM1");
+        domain.setLabel("Domain One");
+        domain.setClients(new HashSet<>()); // Ensure clients set is initialized
+
+        client = new Client();
+        client.setId(101L); // Changed to Long
+        client.setCode("CLI1");
+        client.setLabel("Client One");
+    }
+
+    @Test
+    void createDomain_shouldSaveAndReturnDomain() {
+        // Arrange
+        when(domainRepository.save(any(Domain.class))).thenReturn(domain);
+
+        // Act
+        Domain createdDomain = domainService.createDomain(domain);
+
+        // Assert
+        assertNotNull(createdDomain);
+        assertEquals("DOM1", createdDomain.getCode());
+        verify(domainRepository, times(1)).save(domain);
+    }
+
+    @Test
+    void getDomainById_shouldReturnDomain_whenFound() {
+        // Arrange
+        when(domainRepository.findById(1L)).thenReturn(Optional.of(domain));
+
+        // Act
+        Domain foundDomain = domainService.getDomainById(1L);
+
+        // Assert
+        assertNotNull(foundDomain);
+        assertEquals("DOM1", foundDomain.getCode());
+        verify(domainRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void getDomainById_shouldThrowResourceNotFound_whenNotFound() {
+        // Arrange
+        when(domainRepository.findById(99L)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(ResourceNotFoundException.class, () -> {
+            domainService.getDomainById(99L);
+        });
+        verify(domainRepository, times(1)).findById(99L);
+    }
+
+    @Test
+    void addClientToDomain_shouldAddClientAndSaveDomain() {
+        // Arrange
+        when(domainRepository.findById(1L)).thenReturn(Optional.of(domain));
+        when(clientRepository.save(any(Client.class))).thenReturn(client); // ClientRepository saves the client
+        when(domainRepository.save(any(Domain.class))).thenReturn(domain); // DomainRepository saves the domain with the new client
+
+        // Act
+        Domain updatedDomain = domainService.addClientToDomain(1L, client);
+
+        // Assert
+        assertNotNull(updatedDomain);
+        assertTrue(updatedDomain.getClients().contains(client));
+        assertEquals(1, updatedDomain.getClients().size());
+        verify(domainRepository, times(1)).findById(1L);
+        verify(clientRepository, times(1)).save(client);
+        verify(domainRepository, times(1)).save(domain);
+    }
+}

--- a/src/test/java/com/example/demo/service/EnvironmentServiceTest.java
+++ b/src/test/java/com/example/demo/service/EnvironmentServiceTest.java
@@ -1,0 +1,112 @@
+package com.example.demo.service;
+
+import com.example.demo.exception.ResourceNotFoundException;
+import com.example.demo.model.Environment;
+import com.example.demo.model.Service; // This is the model class for Service
+import com.example.demo.repository.ClientRepository;
+import com.example.demo.repository.EnvironmentRepository;
+import com.example.demo.repository.ServiceRepository; // This is the repository for Service
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class EnvironmentServiceTest {
+
+    @Mock
+    private EnvironmentRepository environmentRepository;
+
+    @Mock
+    private ServiceRepository serviceRepository; // Mock for ServiceRepository
+
+    @Mock
+    private ClientRepository clientRepository; // Mock for ClientRepository
+
+    @InjectMocks
+    private EnvironmentService environmentService;
+
+    private Environment environment;
+    private Service service; // Model instance for Service
+
+    @BeforeEach
+    void setUp() {
+        environment = new Environment();
+        environment.setId(1L); // Changed to Long
+        environment.setName("PROD");
+        environment.setServices(new HashSet<>());
+
+        service = new Service(); // Initialize Service object
+        service.setId(101L); // Changed to Long
+        service.setName("Database Service");
+        service.setType("DATABASE");
+    }
+
+    @Test
+    void createEnvironment_shouldSaveAndReturnEnvironment() {
+        // Arrange
+        when(environmentRepository.save(any(Environment.class))).thenReturn(environment);
+
+        // Act
+        Environment createdEnvironment = environmentService.createEnvironment(environment);
+
+        // Assert
+        assertNotNull(createdEnvironment);
+        assertEquals("PROD", createdEnvironment.getName());
+        verify(environmentRepository, times(1)).save(environment);
+    }
+
+    @Test
+    void getEnvironmentById_shouldReturnEnvironment_whenFound() {
+        // Arrange
+        when(environmentRepository.findById(1L)).thenReturn(Optional.of(environment));
+
+        // Act
+        Environment foundEnvironment = environmentService.getEnvironmentById(1L);
+
+        // Assert
+        assertNotNull(foundEnvironment);
+        assertEquals("PROD", foundEnvironment.getName());
+        verify(environmentRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void getEnvironmentById_shouldThrowResourceNotFound_whenNotFound() {
+        // Arrange
+        when(environmentRepository.findById(99L)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(ResourceNotFoundException.class, () -> {
+            environmentService.getEnvironmentById(99L);
+        });
+        verify(environmentRepository, times(1)).findById(99L);
+    }
+
+    @Test
+    void addServiceToEnvironment_shouldAddServiceAndSaveEnvironment() {
+        // Arrange
+        when(environmentRepository.findById(1L)).thenReturn(Optional.of(environment));
+        when(serviceRepository.save(any(Service.class))).thenReturn(service); // serviceRepository saves the service
+        when(environmentRepository.save(any(Environment.class))).thenReturn(environment); // environmentRepository saves the environment
+
+        // Act
+        Environment updatedEnvironment = environmentService.addServiceToEnvironment(1L, service);
+
+        // Assert
+        assertNotNull(updatedEnvironment);
+        assertTrue(updatedEnvironment.getServices().contains(service));
+        assertEquals(1, updatedEnvironment.getServices().size());
+        verify(environmentRepository, times(1)).findById(1L);
+        verify(serviceRepository, times(1)).save(service);
+        verify(environmentRepository, times(1)).save(environment);
+    }
+}

--- a/src/test/java/com/example/demo/service/TechnicalServiceTest.java
+++ b/src/test/java/com/example/demo/service/TechnicalServiceTest.java
@@ -1,0 +1,110 @@
+package com.example.demo.service;
+
+import com.example.demo.exception.ResourceNotFoundException;
+import com.example.demo.model.Service; // Model class
+import com.example.demo.repository.EnvironmentRepository;
+import com.example.demo.repository.ServiceRepository; // Repository for Service
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class TechnicalServiceTest {
+
+    @Mock
+    private ServiceRepository serviceRepository;
+
+    @Mock
+    private EnvironmentRepository environmentRepository; // Dependency of TechnicalService
+
+    @InjectMocks
+    private TechnicalService technicalService; // The service being tested
+
+    private Service service1;
+    private Service service2;
+
+    @BeforeEach
+    void setUp() {
+        service1 = new Service();
+        service1.setId(1L); // Changed to Long
+        service1.setName("Main Service");
+        service1.setType("BACKEND");
+        service1.setUsedServices(new HashSet<>());
+
+        service2 = new Service();
+        service2.setId(2L); // Changed to Long
+        service2.setName("Dependent Service");
+        service2.setType("DATABASE");
+    }
+
+    @Test
+    void createService_shouldSaveAndReturnService() {
+        // Arrange
+        when(serviceRepository.save(any(Service.class))).thenReturn(service1);
+
+        // Act
+        Service createdService = technicalService.createService(service1);
+
+        // Assert
+        assertNotNull(createdService);
+        assertEquals("Main Service", createdService.getName());
+        verify(serviceRepository, times(1)).save(service1);
+    }
+
+    @Test
+    void getServiceById_shouldReturnService_whenFound() {
+        // Arrange
+        when(serviceRepository.findById(1L)).thenReturn(Optional.of(service1));
+
+        // Act
+        Service foundService = technicalService.getServiceById(1L);
+
+        // Assert
+        assertNotNull(foundService);
+        assertEquals("Main Service", foundService.getName());
+        verify(serviceRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void getServiceById_shouldThrowResourceNotFound_whenNotFound() {
+        // Arrange
+        when(serviceRepository.findById(99L)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(ResourceNotFoundException.class, () -> {
+            technicalService.getServiceById(99L);
+        });
+        verify(serviceRepository, times(1)).findById(99L);
+    }
+
+    @Test
+    void addUsedService_shouldAddDependencyAndSaveService() {
+        // Arrange
+        when(serviceRepository.findById(1L)).thenReturn(Optional.of(service1));
+        when(serviceRepository.findById(2L)).thenReturn(Optional.of(service2));
+        // service1.getUsedServices().add(service2) will be done by the service method
+        when(serviceRepository.save(any(Service.class))).thenReturn(service1);
+
+
+        // Act
+        Service updatedService = technicalService.addUsedService(1L, 2L);
+
+        // Assert
+        assertNotNull(updatedService);
+        assertTrue(updatedService.getUsedServices().contains(service2));
+        assertEquals(1, updatedService.getUsedServices().size());
+        verify(serviceRepository, times(1)).findById(1L);
+        verify(serviceRepository, times(1)).findById(2L);
+        verify(serviceRepository, times(1)).save(service1);
+    }
+}


### PR DESCRIPTION
Replaces String UUIDs with numeric Long IDs for all entities (Domain, Client, Environment, Service).

This change impacts the following areas:
- Entity classes: `id` field changed from String to Long. `@GeneratedValue` will now leverage Neo4j's internal numeric ID generation.
- Repository interfaces: Updated to use Long as the ID type parameter.
- Service classes: All method signatures, parameters, and internal logic updated to handle Long IDs.
- Controller classes: `@PathVariable` annotations and method parameters for IDs changed to Long.
- Unit tests: Test data, mock setups, and assertions updated to use Long IDs. All unit tests pass with these changes.

Manual verification of API endpoints is recommended to ensure end-to-end functionality with numeric IDs.