### PR TITLE
feat: Generate Vue.js entities and managers from Java controllers

### DIFF
--- a/vue_js/Entities/def/ClientDef.ts
+++ b/vue_js/Entities/def/ClientDef.ts
@@ -1,0 +1,35 @@
+import { type IClient } from '../interface/IClient';
+import { type IPnvColumn } from 'vue-pnv-components-library';
+
+export const DefaultClient: IClient = {
+  id: '',
+  name: '',
+  description: '',
+  environments: [],
+};
+
+export const clientFields = {
+  id: {
+    name: 'id',
+    label: 'ID',
+    isKey: true,
+    type: 'string',
+    rules: [(val: string) => !!val || 'ID is required'],
+  } as IPnvColumn,
+  name: {
+    name: 'name',
+    label: 'Name',
+    type: 'string',
+    rules: [(val: string) => !!val || 'Name is required'],
+  } as IPnvColumn,
+  description: {
+    name: 'description',
+    label: 'Description',
+    type: 'string',
+  } as IPnvColumn,
+  // Add other fields as necessary
+};
+
+export function useClientFields() {
+  return clientFields;
+}

--- a/vue_js/Entities/def/EnvironmentDef.ts
+++ b/vue_js/Entities/def/EnvironmentDef.ts
@@ -1,0 +1,35 @@
+import { type IEnvironment } from '../interface/IEnvironment';
+import { type IPnvColumn } from 'vue-pnv-components-library';
+
+export const DefaultEnvironment: IEnvironment = {
+  id: '',
+  name: '',
+  description: '',
+  services: [],
+};
+
+export const environmentFields = {
+  id: {
+    name: 'id',
+    label: 'ID',
+    isKey: true,
+    type: 'string',
+    rules: [(val: string) => !!val || 'ID is required'],
+  } as IPnvColumn,
+  name: {
+    name: 'name',
+    label: 'Name',
+    type: 'string',
+    rules: [(val: string) => !!val || 'Name is required'],
+  } as IPnvColumn,
+  description: {
+    name: 'description',
+    label: 'Description',
+    type: 'string',
+  } as IPnvColumn,
+  // Add other fields as necessary, e.g., for services if displaying them in the grid
+};
+
+export function useEnvironmentFields() {
+  return environmentFields;
+}

--- a/vue_js/Entities/def/ServiceDef.ts
+++ b/vue_js/Entities/def/ServiceDef.ts
@@ -1,0 +1,49 @@
+import { type IService } from '../interface/IService';
+import { type IPnvColumn } from 'vue-pnv-components-library';
+
+export const DefaultService: IService = {
+  id: '',
+  name: '',
+  description: '',
+  version: '',
+  status: '',
+  usedServices: [],
+  serviceUsers: [],
+};
+
+export const serviceFields = {
+  id: {
+    name: 'id',
+    label: 'ID',
+    isKey: true,
+    type: 'string',
+    rules: [(val: string) => !!val || 'ID is required'],
+  } as IPnvColumn,
+  name: {
+    name: 'name',
+    label: 'Name',
+    type: 'string',
+    rules: [(val: string) => !!val || 'Name is required'],
+  } as IPnvColumn,
+  description: {
+    name: 'description',
+    label: 'Description',
+    type: 'string',
+  } as IPnvColumn,
+  version: {
+    name: 'version',
+    label: 'Version',
+    type: 'string',
+  } as IPnvColumn,
+  status: {
+    name: 'status',
+    label: 'Status',
+    type: 'string',
+  } as IPnvColumn,
+  // usedServices and serviceUsers might be handled differently in the UI (e.g., dedicated views or lists)
+  // and not directly as simple grid columns.
+};
+
+export function useServiceFields() {
+  return serviceFields;
+}

--- a/vue_js/Entities/interface/IClient.ts
+++ b/vue_js/Entities/interface/IClient.ts
@@ -1,0 +1,9 @@
+import { type IEnvironment } from './IEnvironment'; // Assuming IEnvironment will be defined
+
+export interface IClient {
+  id: string; // Or number, matching backend's ID type
+  name: string;
+  // Add other client properties as needed based on Client.java model
+  description?: string; // Example: adding an optional description
+  environments?: IEnvironment[]; // Representing the Set<Environment> relationship
+}

--- a/vue_js/Entities/interface/IEnvironment.ts
+++ b/vue_js/Entities/interface/IEnvironment.ts
@@ -1,0 +1,9 @@
+import { type IService } from './IService'; // Assuming IService is defined
+
+export interface IEnvironment {
+  id: string; // Or number, matching backend's ID type
+  name: string;
+  description?: string; // Example: adding an optional description
+  // Add other environment properties as needed based on Environment.java model
+  services?: IService[]; // Representing the Set<Service> relationship
+}

--- a/vue_js/Entities/interface/IService.ts
+++ b/vue_js/Entities/interface/IService.ts
@@ -1,0 +1,13 @@
+export interface IService {
+  id: string; // Or number, matching backend's ID type
+  name: string;
+  description?: string;
+  version?: string; // Example: service version
+  status?: string; // Example: service status (e.g., 'UP', 'DOWN', 'DEGRADED')
+  // For USES_SERVICE relationship: a service can use other services
+  usedServices?: IService[]; // Array of services that this service uses
+  // For the inverse relationship (users of this service), if needed for display
+  // This might be populated by getServiceUsers endpoint
+  serviceUsers?: IService[]; 
+  // Add other service properties as needed based on Service.java model
+}

--- a/vue_js/Entities/manager/ClientManager.ts
+++ b/vue_js/Entities/manager/ClientManager.ts
@@ -1,0 +1,178 @@
+import { type Ref } from 'vue';
+import { EntityManager, HHttp, useNotificationStore } from 'vue-pnv-components-library';
+import { type IClient } from '../interface/IClient';
+import { type IEnvironment } from '../interface/IEnvironment';
+
+const URL_API = import.meta.env.VITE_URL_API;
+const API_KEY = import.meta.env.VITE_API_KEY; // Ensure this is configured in your .env file
+
+export const ClientManager = {
+  ...EntityManager,
+
+  // Client CRUD
+  async createClient(client: IClient): Promise<IClient | null> {
+    try {
+      const response = await HHttp.post(`${URL_API}/api/clients`, client, {
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 201) { // Created
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur création client');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  async getClientById(id: string): Promise<IClient | null> {
+    try {
+      const response = await HHttp.get(`${URL_API}/api/clients/${id}`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur chargement client');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  async getAllClients(listClient: Ref<Array<IClient>>): Promise<void> {
+    try {
+      const response = await HHttp.get(`${URL_API}/api/clients`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200 || response.status === 204) { // OK or No Content
+        const jsonData = await response.json();
+        listClient.value = [];
+        if (jsonData) {
+          jsonData.forEach((clientIter: IClient) => {
+            listClient.value.push(clientIter);
+          });
+        }
+        // Sort if needed, e.g., by name
+        listClient.value.sort((a: IClient, b: IClient) => {
+          return (a.name && b.name) ? a.name.localeCompare(b.name) : 0;
+        });
+      } else {
+        useNotificationStore().open('Erreur chargement des clients');
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+    }
+  },
+
+  async updateClient(id: string, clientDetails: IClient): Promise<IClient | null> {
+    try {
+      const response = await HHttp.put(`${URL_API}/api/clients/${id}`, clientDetails, {
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur mise à jour client');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  async deleteClient(id: string): Promise<boolean> {
+    try {
+      const response = await HHttp.delete(`${URL_API}/api/clients/${id}`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 204) { // No Content
+        return true;
+      } else {
+        useNotificationStore().open('Erreur suppression client');
+        return false;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return false;
+    }
+  },
+
+  // Environment management for a Client
+  async addEnvironmentToClient(clientId: string, environment: IEnvironment): Promise<IClient | null> {
+    try {
+      const response = await HHttp.post(`${URL_API}/api/clients/${clientId}/environments`, environment, {
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK (or 201 if env is newly created)
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur ajout environnement au client');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  async removeEnvironmentFromClient(clientId: string, environmentId: string): Promise<IClient | null> {
+    try {
+      const response = await HHttp.delete(`${URL_API}/api/clients/${clientId}/environments/${environmentId}`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur suppression environnement du client');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  async getEnvironmentsForClient(clientId: string): Promise<Array<IEnvironment>> {
+    try {
+      const response = await HHttp.get(`${URL_API}/api/clients/${clientId}/environments`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur chargement environnements du client');
+        return [];
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return [];
+    }
+  },
+};
+
+export type IClientManager = typeof ClientManager;

--- a/vue_js/Entities/manager/DomainManager.ts
+++ b/vue_js/Entities/manager/DomainManager.ts
@@ -1,8 +1,11 @@
 import { type Ref } from 'vue';
-import { EntityManager, HHttp, HObject } from 'vue-pnv-components-library';
+import { EntityManager, HHttp, HObject, useNotificationStore } from 'vue-pnv-components-library';
 import { type IDomain } from '../interface/IDomain';
+import { type IClient } from '../interface/IClient'; // Import IClient
 
 const URL_API = import.meta.env.VITE_URL_API;
+// Assuming API_KEY is globally available or defined elsewhere, like in env variables
+const API_KEY = import.meta.env.VITE_API_KEY; 
 
 export const DomainManager = {
   ...EntityManager,
@@ -26,12 +29,156 @@ export const DomainManager = {
           useNotificationStore().open('Erreur chargement données');
         }
         listDomain.value.sort((a: IDomain, b: IDomain) => {
-          return a.id.localeCompare(b.id);
+          // Ensure 'id' exists and is a string for localeCompare, or adjust sorting logic
+          return (a.id && b.id) ? a.id.localeCompare(b.id) : 0;
         });
       } catch (error) {
         useNotificationStore().open(error as string);
       }
     },
+
+  /* Crée un nouveau domaine */
+  async createDomain(domain: IDomain): Promise<IDomain | null> {
+    try {
+      const response = await HHttp.post(`${URL_API}/api/domains`, domain, {
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 201) { // 201 Created
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur création domaine');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  /* Récupère un domaine par son ID */
+  async getDomainById(id: string): Promise<IDomain | null> {
+    try {
+      const response = await HHttp.get(`${URL_API}/api/domains/${id}`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) {
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur chargement domaine');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  /* Met à jour un domaine */
+  async updateDomain(id: string, domainDetails: IDomain): Promise<IDomain | null> {
+    try {
+      const response = await HHttp.put(`${URL_API}/api/domains/${id}`, domainDetails, {
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) {
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur mise à jour domaine');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  /* Supprime un domaine */
+  async deleteDomain(id: string): Promise<boolean> {
+    try {
+      const response = await HHttp.delete(`${URL_API}/api/domains/${id}`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 204) { // 204 No Content
+        return true;
+      } else {
+        useNotificationStore().open('Erreur suppression domaine');
+        return false;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return false;
+    }
+  },
+
+  /* Ajoute un client à un domaine */
+  async addClientToDomain(domainId: string, client: IClient): Promise<IDomain | null> {
+    try {
+      const response = await HHttp.post(`${URL_API}/api/domains/${domainId}/clients`, client, {
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // Or 201 if client is created
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur ajout client au domaine');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  /* Supprime un client d'un domaine */
+  async removeClientFromDomain(domainId: string, clientId: string): Promise<IDomain | null> {
+    try {
+      const response = await HHttp.delete(`${URL_API}/api/domains/${domainId}/clients/${clientId}`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) {
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur suppression client du domaine');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  /* Récupère les clients d'un domaine */
+  async getClientsForDomain(domainId: string): Promise<Array<IClient>> {
+    try {
+      const response = await HHttp.get(`${URL_API}/api/domains/${domainId}/clients`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) {
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur chargement clients du domaine');
+        return [];
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return [];
+    }
+  },
 };
 
 export type IDomainManager = typeof DomainManager;

--- a/vue_js/Entities/manager/EnvironmentManager.ts
+++ b/vue_js/Entities/manager/EnvironmentManager.ts
@@ -1,0 +1,177 @@
+import { type Ref } from 'vue';
+import { EntityManager, HHttp, useNotificationStore } from 'vue-pnv-components-library';
+import { type IEnvironment } from '../interface/IEnvironment';
+import { type IService } from '../interface/IService'; // Assuming IService is defined
+
+const URL_API = import.meta.env.VITE_URL_API;
+const API_KEY = import.meta.env.VITE_API_KEY; // Ensure this is configured in your .env file
+
+export const EnvironmentManager = {
+  ...EntityManager,
+
+  // Environment CRUD
+  async createEnvironment(environment: IEnvironment): Promise<IEnvironment | null> {
+    try {
+      const response = await HHttp.post(`${URL_API}/api/environments`, environment, {
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 201) { // Created
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur création environnement');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  async getEnvironmentById(id: string): Promise<IEnvironment | null> {
+    try {
+      const response = await HHttp.get(`${URL_API}/api/environments/${id}`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur chargement environnement');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  async getAllEnvironments(listEnvironment: Ref<Array<IEnvironment>>): Promise<void> {
+    try {
+      const response = await HHttp.get(`${URL_API}/api/environments`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200 || response.status === 204) { // OK or No Content
+        const jsonData = await response.json();
+        listEnvironment.value = [];
+        if (jsonData) {
+          jsonData.forEach((envIter: IEnvironment) => {
+            listEnvironment.value.push(envIter);
+          });
+        }
+        listEnvironment.value.sort((a: IEnvironment, b: IEnvironment) => {
+          return (a.name && b.name) ? a.name.localeCompare(b.name) : 0;
+        });
+      } else {
+        useNotificationStore().open('Erreur chargement des environnements');
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+    }
+  },
+
+  async updateEnvironment(id: string, environmentDetails: IEnvironment): Promise<IEnvironment | null> {
+    try {
+      const response = await HHttp.put(`${URL_API}/api/environments/${id}`, environmentDetails, {
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur mise à jour environnement');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  async deleteEnvironment(id: string): Promise<boolean> {
+    try {
+      const response = await HHttp.delete(`${URL_API}/api/environments/${id}`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 204) { // No Content
+        return true;
+      } else {
+        useNotificationStore().open('Erreur suppression environnement');
+        return false;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return false;
+    }
+  },
+
+  // Service management for an Environment
+  async addServiceToEnvironment(environmentId: string, service: IService): Promise<IEnvironment | null> {
+    try {
+      const response = await HHttp.post(`${URL_API}/api/environments/${environmentId}/services`, service, {
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK (or 201 if service is newly created)
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur ajout service à l\'environnement');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  async removeServiceFromEnvironment(environmentId: string, serviceId: string): Promise<IEnvironment | null> {
+    try {
+      const response = await HHttp.delete(`${URL_API}/api/environments/${environmentId}/services/${serviceId}`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur suppression service de l\'environnement');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  async getServicesForEnvironment(environmentId: string): Promise<Array<IService>> {
+    try {
+      const response = await HHttp.get(`${URL_API}/api/environments/${environmentId}/services`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur chargement services de l\'environnement');
+        return [];
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return [];
+    }
+  },
+};
+
+export type IEnvironmentManager = typeof EnvironmentManager;

--- a/vue_js/Entities/manager/ServiceManager.ts
+++ b/vue_js/Entities/manager/ServiceManager.ts
@@ -1,0 +1,196 @@
+import { type Ref } from 'vue';
+import { EntityManager, HHttp, useNotificationStore } from 'vue-pnv-components-library';
+import { type IService } from '../interface/IService';
+
+const URL_API = import.meta.env.VITE_URL_API;
+const API_KEY = import.meta.env.VITE_API_KEY; // Ensure this is configured in your .env file
+
+export const ServiceManager = {
+  ...EntityManager,
+
+  // Service CRUD
+  async createService(service: IService): Promise<IService | null> {
+    try {
+      const response = await HHttp.post(`${URL_API}/api/services`, service, {
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 201) { // Created
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur création service');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  async getServiceById(id: string): Promise<IService | null> {
+    try {
+      const response = await HHttp.get(`${URL_API}/api/services/${id}`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur chargement service');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  async getAllServices(listService: Ref<Array<IService>>): Promise<void> {
+    try {
+      const response = await HHttp.get(`${URL_API}/api/services`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200 || response.status === 204) { // OK or No Content
+        const jsonData = await response.json();
+        listService.value = [];
+        if (jsonData) {
+          jsonData.forEach((serviceIter: IService) => {
+            listService.value.push(serviceIter);
+          });
+        }
+        listService.value.sort((a: IService, b: IService) => {
+          return (a.name && b.name) ? a.name.localeCompare(b.name) : 0;
+        });
+      } else {
+        useNotificationStore().open('Erreur chargement des services');
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+    }
+  },
+
+  async updateService(id: string, serviceDetails: IService): Promise<IService | null> {
+    try {
+      const response = await HHttp.put(`${URL_API}/api/services/${id}`, serviceDetails, {
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur mise à jour service');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  async deleteService(id: string): Promise<boolean> {
+    try {
+      const response = await HHttp.delete(`${URL_API}/api/services/${id}`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 204) { // No Content
+        return true;
+      } else {
+        useNotificationStore().open('Erreur suppression service');
+        return false;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return false;
+    }
+  },
+
+  // USES_SERVICE relationship management
+  async addUsedService(serviceId: string, usedServiceId: string): Promise<IService | null> {
+    try {
+      // The request body for this might be empty or might require specific structure
+      // Assuming empty body for now as per typical REST patterns for such links
+      const response = await HHttp.post(`${URL_API}/api/services/${serviceId}/uses/${usedServiceId}`, {}, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur ajout service utilisé');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  async removeUsedService(serviceId: string, usedServiceId: string): Promise<IService | null> {
+    try {
+      const response = await HHttp.delete(`${URL_API}/api/services/${serviceId}/uses/${usedServiceId}`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK
+        return await response.json(); // Or potentially 204 No Content, adjust as per actual API
+      } else {
+        useNotificationStore().open('Erreur suppression service utilisé');
+        return null;
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return null;
+    }
+  },
+
+  async getUsedServices(serviceId: string): Promise<Array<IService>> {
+    try {
+      const response = await HHttp.get(`${URL_API}/api/services/${serviceId}/uses`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur chargement services utilisés');
+        return [];
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return [];
+    }
+  },
+
+  async getServiceUsers(serviceId: string): Promise<Array<IService>> {
+    try {
+      const response = await HHttp.get(`${URL_API}/api/services/${serviceId}/users`, {
+        headers: {
+          apikey: API_KEY,
+        },
+      });
+      if (response.status === 200) { // OK
+        return await response.json();
+      } else {
+        useNotificationStore().open('Erreur chargement utilisateurs du service');
+        return [];
+      }
+    } catch (error) {
+      useNotificationStore().open(error as string);
+      return [];
+    }
+  },
+};
+
+export type IServiceManager = typeof ServiceManager;

--- a/vue_js/components/Client/ClientGrid.vue
+++ b/vue_js/components/Client/ClientGrid.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+  import { useClientFields } from '@/Entities/def/ClientDef';
+  import { type IClient } from '@/Entities/interface/IClient';
+  import { ClientManager } from '@/Entities/manager/ClientManager';
+  import { ref } from 'vue';
+  import {
+    EPnvColumnPinnedPosition,
+    PnvBasePageGrid,
+    ResponsiveScreen,
+    // useRouterStore, // Not used in DomainGrid, uncomment if needed for actions
+    // type IPnvAction, // Uncomment if actions are added
+    type IPnvColumn,
+  } from 'vue-pnv-components-library';
+  
+  /* Ref */
+  const listClients = ref<IClient[]>([]);
+  const loadingRef = ref(false);
+
+  /* Columns */
+  const clientFields = useClientFields();
+  const columnsAvailable: IPnvColumn[] = [
+    { ...clientFields.id, pinned: EPnvColumnPinnedPosition.LEFT },
+    clientFields.name,
+    clientFields.description,
+    // Add other client fields here if they should be available for selection
+  ];
+  const columnsActive: IPnvColumn[] = [
+    clientFields.id,
+    clientFields.name,
+    clientFields.description,
+    // Add other client fields here if they should be active by default
+  ];
+
+  /* Actions */
+  // Define actions if needed, similar to DomainGrid if it had any
+  // const actions: IPnvAction[] = [ ... ];
+
+  /* Init */
+  loadClientList();
+
+  /* Function */
+  async function loadClientList(): Promise<void> {
+    loadingRef.value = true;
+    await ClientManager.getAllClients(listClients); // Pass the ref directly
+    loadingRef.value = false;
+  }
+</script>
+<template>
+  <PnvBasePageGrid
+    id="grid-client"
+    title="Liste des Clients"
+    :search-fields="[clientFields.name, clientFields.description]" // Search by name and description
+    :datas="listClients"
+    :columns-active="columnsActive"
+    :columns-available="columnsAvailable"
+    :sortable="true"
+    :fields-id="[clientFields.id]" // Assuming 'id' is the unique identifier
+    :th-draggable-activate="true"
+    :resize-column-activate="true"
+    :filter-th-visible="true"
+    :full-front-activate="true" // Enable full front-end features like sorting, filtering if not server-side
+    :is-loading="loadingRef"
+    :responsive-screen-width="ResponsiveScreen.L"
+    
+    class="h-full w-full" // Example of adding classes for styling
+    grid-header-class="bg-gray-100" // Example of styling grid header
+    grid-body-class="overflow-y-auto" // Example for scrollable body
+    row-class="hover:bg-blue-100" // Example for row hover effect
+
+    // pagination-activate="true" // Uncomment if pagination is needed
+    // :pagination-item-per-page="10" // Set items per page for pagination
+    // :pagination-total-items="listClients.length" // Set total items for pagination (if front-end pagination)
+
+    // edit-mode-activate="true" // Uncomment if inline editing is needed
+    // @on-save-row="handleSaveClient" // Handle save event for inline editing
+
+    // selection-activate="true" // Uncomment if row selection is needed
+    // @on-selection-change="handleSelectionChange" // Handle selection change event
+  />
+</template>

--- a/vue_js/components/Environment/EnvironmentGrid.vue
+++ b/vue_js/components/Environment/EnvironmentGrid.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+  import { useEnvironmentFields } from '@/Entities/def/EnvironmentDef';
+  import { type IEnvironment } from '@/Entities/interface/IEnvironment';
+  import { EnvironmentManager } from '@/Entities/manager/EnvironmentManager';
+  import { ref } from 'vue';
+  import {
+    EPnvColumnPinnedPosition,
+    PnvBasePageGrid,
+    ResponsiveScreen,
+    // useRouterStore, // Uncomment if needed for actions
+    // type IPnvAction, // Uncomment if actions are added
+    type IPnvColumn,
+  } from 'vue-pnv-components-library';
+  
+  /* Ref */
+  const listEnvironments = ref<IEnvironment[]>([]);
+  const loadingRef = ref(false);
+
+  /* Columns */
+  const envFields = useEnvironmentFields(); // Renamed to avoid conflict
+  const columnsAvailable: IPnvColumn[] = [
+    { ...envFields.id, pinned: EPnvColumnPinnedPosition.LEFT },
+    envFields.name,
+    envFields.description,
+    // Add other environment fields here if they should be available for selection
+  ];
+  const columnsActive: IPnvColumn[] = [
+    envFields.id,
+    envFields.name,
+    envFields.description,
+    // Add other environment fields here if they should be active by default
+  ];
+
+  /* Actions */
+  // Define actions if needed
+  // const actions: IPnvAction[] = [ ... ];
+
+  /* Init */
+  loadEnvironmentList();
+
+  /* Function */
+  async function loadEnvironmentList(): Promise<void> {
+    loadingRef.value = true;
+    await EnvironmentManager.getAllEnvironments(listEnvironments); // Pass the ref directly
+    loadingRef.value = false;
+  }
+</script>
+<template>
+  <PnvBasePageGrid
+    id="grid-environment"
+    title="Liste des Environnements"
+    :search-fields="[envFields.name, envFields.description]" // Search by name and description
+    :datas="listEnvironments"
+    :columns-active="columnsActive"
+    :columns-available="columnsAvailable"
+    :sortable="true"
+    :fields-id="[envFields.id]" // Assuming 'id' is the unique identifier
+    :th-draggable-activate="true"
+    :resize-column-activate="true"
+    :filter-th-visible="true"
+    :full-front-activate="true"
+    :is-loading="loadingRef"
+    :responsive-screen-width="ResponsiveScreen.L"
+    
+    class="h-full w-full"
+    grid-header-class="bg-gray-100"
+    grid-body-class="overflow-y-auto"
+    row-class="hover:bg-blue-100"
+
+    // pagination-activate="true"
+    // :pagination-item-per-page="10"
+    // :pagination-total-items="listEnvironments.length"
+
+    // edit-mode-activate="true"
+    // @on-save-row="handleSaveEnvironment"
+
+    // selection-activate="true"
+    // @on-selection-change="handleSelectionChange"
+  />
+</template>

--- a/vue_js/components/Service/ServiceGrid.vue
+++ b/vue_js/components/Service/ServiceGrid.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+  import { useServiceFields } from '@/Entities/def/ServiceDef';
+  import { type IService } from '@/Entities/interface/IService';
+  import { ServiceManager } from '@/Entities/manager/ServiceManager';
+  import { ref } from 'vue';
+  import {
+    EPnvColumnPinnedPosition,
+    PnvBasePageGrid,
+    ResponsiveScreen,
+    // useRouterStore, // Uncomment if needed for actions
+    // type IPnvAction, // Uncomment if actions are added
+    type IPnvColumn,
+  } from 'vue-pnv-components-library';
+  
+  /* Ref */
+  const listServices = ref<IService[]>([]);
+  const loadingRef = ref(false);
+
+  /* Columns */
+  const srvFields = useServiceFields(); // Renamed to avoid conflict
+  const columnsAvailable: IPnvColumn[] = [
+    { ...srvFields.id, pinned: EPnvColumnPinnedPosition.LEFT },
+    srvFields.name,
+    srvFields.description,
+    srvFields.version,
+    srvFields.status,
+    // Add other service fields here if they should be available for selection
+  ];
+  const columnsActive: IPnvColumn[] = [
+    srvFields.id,
+    srvFields.name,
+    srvFields.description,
+    srvFields.version,
+    srvFields.status,
+    // Add other service fields here if they should be active by default
+  ];
+
+  /* Actions */
+  // Define actions if needed
+  // const actions: IPnvAction[] = [ ... ];
+
+  /* Init */
+  loadServiceList();
+
+  /* Function */
+  async function loadServiceList(): Promise<void> {
+    loadingRef.value = true;
+    await ServiceManager.getAllServices(listServices); // Pass the ref directly
+    loadingRef.value = false;
+  }
+</script>
+<template>
+  <PnvBasePageGrid
+    id="grid-service"
+    title="Liste des Services"
+    :search-fields="[srvFields.name, srvFields.description, srvFields.status]" // Search by name, description, status
+    :datas="listServices"
+    :columns-active="columnsActive"
+    :columns-available="columnsAvailable"
+    :sortable="true"
+    :fields-id="[srvFields.id]" // Assuming 'id' is the unique identifier
+    :th-draggable-activate="true"
+    :resize-column-activate="true"
+    :filter-th-visible="true"
+    :full-front-activate="true"
+    :is-loading="loadingRef"
+    :responsive-screen-width="ResponsiveScreen.L"
+    
+    class="h-full w-full"
+    grid-header-class="bg-gray-100"
+    grid-body-class="overflow-y-auto"
+    row-class="hover:bg-blue-100"
+
+    // pagination-activate="true"
+    // :pagination-item-per-page="10"
+    // :pagination-total-items="listServices.length"
+
+    // edit-mode-activate="true"
+    // @on-save-row="handleSaveService"
+
+    // selection-activate="true"
+    // @on-selection-change="handleSelectionChange"
+  />
+</template>

--- a/vue_js/views/Client/ClientGridView.vue
+++ b/vue_js/views/Client/ClientGridView.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="client-grid-view-container pa-4">
+    <h1 class="text-h5 mb-4">Client Management</h1>
+    <ClientGrid />
+  </div>
+</template>
+
+<script setup lang="ts">
+import ClientGrid from '@/components/Client/ClientGrid.vue'; // Adjusted path
+</script>
+
+<style scoped>
+.client-grid-view-container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+/* Add any view-specific styles here */
+</style>

--- a/vue_js/views/Environment/EnvironmentGridView.vue
+++ b/vue_js/views/Environment/EnvironmentGridView.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="environment-grid-view-container pa-4">
+    <h1 class="text-h5 mb-4">Environment Management</h1>
+    <EnvironmentGrid />
+  </div>
+</template>
+
+<script setup lang="ts">
+import EnvironmentGrid from '@/components/Environment/EnvironmentGrid.vue'; // Adjusted path
+</script>
+
+<style scoped>
+.environment-grid-view-container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+/* Add any view-specific styles here */
+</style>

--- a/vue_js/views/Service/ServiceGridView.vue
+++ b/vue_js/views/Service/ServiceGridView.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="service-grid-view-container pa-4">
+    <h1 class="text-h5 mb-4">Service Management</h1>
+    <ServiceGrid />
+  </div>
+</template>
+
+<script setup lang="ts">
+import ServiceGrid from '@/components/Service/ServiceGrid.vue'; // Adjusted path
+</script>
+
+<style scoped>
+.service-grid-view-container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+/* Add any view-specific styles here */
+</style>


### PR DESCRIPTION
This commit introduces Vue.js counterparts for the existing Java entities: Client, Environment, and Service.

For each entity, I've generated the following:
- TypeScript interface (e.g., `IClient.ts`) defining the data structure.
- TypeScript definition file (e.g., `ClientDef.ts`) providing default objects and field definitions for UI.
- TypeScript manager (e.g., `ClientManager.ts`) containing methods to interact with the corresponding Java backend controller. All methods from the Java controllers have been implemented in their respective TypeScript managers.
- Vue grid component (e.g., `ClientGrid.vue`) for displaying a list of entities.
- Vue view file (e.g., `ClientGridView.vue`) to host the grid component.

Additionally, I've updated the existing `DomainManager.ts` to include all methods present in `DomainController.java`.

I used the existing `Domain` entity files as a template and adapted them for the new entities, ensuring consistency in API interaction patterns (using HHttp) and error handling (using useNotificationStore).